### PR TITLE
Add dataLayer push

### DIFF
--- a/resources/js/components/Form.vue
+++ b/resources/js/components/Form.vue
@@ -55,6 +55,13 @@ export default {
                     } else {
                         Notify(window.config.translations.order_reminder.add, 'success')
                     }
+
+                    if ('dataLayer' in window) {
+                        window.dataLayer.push({
+                            event: 'order_reminder',
+                            reminder: this.variables,
+                        })
+                    }
                 }).catch(response => {
                     this.toggleForm()
                     if (response?.response?.status === 403) {


### PR DESCRIPTION
Adds a custom datalayer push on a successful order reminder submit that can be hooked into with tag manager. Might be overkill, or otherwise may be entirely useless because errors shouldn't really happen.