### PR TITLE
Cast timespan to integer

### DIFF
--- a/src/Models/OrderReminder.php
+++ b/src/Models/OrderReminder.php
@@ -17,7 +17,8 @@ class OrderReminder extends Model
     protected $appends = ['reminder_date'];
 
     protected $casts = [
-        'renewal_date' => 'datetime'
+        'renewal_date' => 'datetime',
+        'timespan' => 'integer',
     ];
 
     protected static function booted(): void


### PR DESCRIPTION
Makes sure that the timespan value is cast to an integer. Carbon does not like it when this is a string value.